### PR TITLE
workaround for failed "get" commands

### DIFF
--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -44,9 +44,9 @@ define staging::file (
     path        => $staging::exec_path,
     environment => $environment,
     cwd         => $staging_dir,
-    creates     => $target_file,
     timeout     => $timeout,
     logoutput   => on_failure,
+    unless      => "/bin/test -s ${target_file}",
   }
 
   case $::staging_http_get {


### PR DESCRIPTION
Sometimes commands like wget fail to download a file and create a file with 0 length instead
The next time agent runs it will see the file and won't retry to download it again.
It's hard to imagine someone would ever want to stage an empty file, so this
workaround should work in general cases