### PR TITLE
Add support for .deb archives.

### DIFF
--- a/manifests/extract.pp
+++ b/manifests/extract.pp
@@ -98,6 +98,14 @@ define staging::extract (
       $command = "jar xf ${source_path}"
     }
 
+    /.deb$/: {
+      if $::osfamily == 'Debian' {
+        $command = "dpkg --extract ${source_path} ."
+      } else {
+        fail('The .deb filetype is only supported on Debian family systems.')
+      }
+    }
+
     default: {
       fail("staging::extract: unsupported file format ${name}.")
     }

--- a/spec/defines/staging_extract_spec.rb
+++ b/spec/defines/staging_extract_spec.rb
@@ -96,6 +96,34 @@ describe 'staging::extract', :type => :define do
     }
   end
 
+  describe 'when deploying deb on a Debian family system' do
+    let(:facts) {{
+      :osfamily => 'Debian',
+      :path     => '/usr/local/bin:/usr/bin:/bin'
+    }}
+    let(:title) { 'sample.deb' }
+    let(:params) { { :target => '/opt' } }
+
+    it { should contain_file('/opt/staging')
+      should contain_exec('extract sample.deb').with({
+        :command => 'dpkg --extract /opt/staging//sample.deb .',
+        :path    => '/usr/local/bin:/usr/bin:/bin',
+        :cwd     => '/opt',
+        :creates => '/opt/sample'
+      })
+    }
+  end
+
+  describe 'when deploying deb on a non-Debian family system' do
+    let(:title) { 'sample.deb' }
+    let(:params) { { :target => '/opt' } }
+
+    it 'should fail' do
+      should compile.and_raise_error(/The .deb filetype is only supported on Debian family systems./)
+    end
+
+  end
+
   describe 'when deploying unknown' do
      let(:title) { 'sample.zzz'}
      let(:params) { { :target => '/opt' } }


### PR DESCRIPTION
It's sometimes required to extract the contents of a software package
the same way any archive would be done. This is the case when a Debian
package is only distributed as such and not as tar.gz or similar.
Dpkg supports extracting packages.