### PR TITLE
Error parsing this YAML file.

### DIFF
--- a/spec/fixtures/hiera.yaml
+++ b/spec/fixtures/hiera.yaml
@@ -1,7 +1,9 @@
 ---
-:backends: - puppet
+:backends: 
+ - puppet
 
-:hierarchy: - common
+:hierarchy: 
+ - common
 
 :puppet:
     :datasource: data


### PR DESCRIPTION
Hi,

As a pre-commit hook I'm checking to see that my code is able to be parsed, like so: 

```shell
for file in `git diff-index --cached --diff-filter=AM --name-only HEAD`
do
  echo "Validating ${file}..."

  case "${file##*.}" in
    "pp")  puppet parser validate ${file}
           ;;

    "erb") /opt/puppet/bin/erb -P -x -T '-' ${file} | /opt/puppet/bin/ruby -c >/dev/null
           ;;

    "yaml") /opt/puppet/bin/ruby -ryaml -e "YAML.load_file '${file}'" >/dev/null
           ;;

  esac

  EXITCODE=$((EXITCODE + $?))
done
```
This file causes the pre-commit hook to fail with the following error: 

```bash
root@klynton:puppetcode # git commit -m 'really'
Validating modules/staging/spec/fixtures/hiera.yaml...
/opt/puppet/lib/ruby/1.9.1/psych.rb:203:in `parse': (modules/staging/spec/fixtures/hiera.yaml): block sequence entries are not allowed in this context at line 2 column 12 (Psych::SyntaxError)
	from /opt/puppet/lib/ruby/1.9.1/psych.rb:203:in `parse_stream'
	from /opt/puppet/lib/ruby/1.9.1/psych.rb:151:in `parse'
	from /opt/puppet/lib/ruby/1.9.1/psych.rb:127:in `load'
	from /opt/puppet/lib/ruby/1.9.1/psych.rb:297:in `block in load_file'
	from /opt/puppet/lib/ruby/1.9.1/psych.rb:297:in `open'
	from /opt/puppet/lib/ruby/1.9.1/psych.rb:297:in `load_file'
	from -e:1:in `<main>'

################################################################
### Please fix the errors above before committing your code. ###
################################################################

root@klynton:puppetcode #
```

This simple change allows the YAML to be parsed.