### PR TITLE
Add support for unzip options

### DIFF
--- a/manifests/deploy.pp
+++ b/manifests/deploy.pp
@@ -8,6 +8,7 @@ define staging::deploy (
   $password     = undef, #: https or ftp user password or https certificate password
   $environment  = undef, #: environment variable for settings such as http_proxy
   $strip        = undef, #: extract file with the --strip=X option. Only works with GNU tar.
+  $unzip_opts   = '',    #: additional options to pass the unzip command.
   $timeout      = undef, #: the time to wait for the file transfer to complete
   $user         = undef, #: extract file as this user
   $group        = undef, #: extract group as this group
@@ -34,6 +35,7 @@ define staging::deploy (
     group       => $group,
     environment => $environment,
     strip       => $strip,
+    unzip_opts  => $unzip_opts,
     subdir      => $caller_module_name,
     creates     => $creates,
     unless      => $unless,

--- a/manifests/extract.pp
+++ b/manifests/extract.pp
@@ -9,6 +9,7 @@ define staging::extract (
   $group       = undef, #:  extract file as this group.
   $environment = undef, #: environment variables.
   $strip       = undef, #: extract file with the --strip=X option. Only works with GNU tar.
+  $unzip_opts  = '',    #: additional options to pass the unzip command.
   $subdir      = $caller_module_name #: subdir per module in staging directory.
 ) {
 
@@ -91,7 +92,7 @@ define staging::extract (
     }
 
     /.zip$/: {
-      $command = "unzip ${source_path}"
+      $command = "unzip ${unzip_opts} ${source_path}"
     }
 
     /(.war|.jar)$/: {

--- a/spec/defines/staging_deploy_spec.rb
+++ b/spec/defines/staging_deploy_spec.rb
@@ -31,7 +31,7 @@ describe 'staging::deploy', :type => :define do
     let(:title) { 'sample.tar.gz' }
     let(:params) {{
       :source => 'puppet:///modules/staging/sample.tar.gz',
-      :target => '/usr/local' ,
+      :target => '/usr/local',
       :strip  => 1
     }}
 
@@ -47,4 +47,23 @@ describe 'staging::deploy', :type => :define do
     }
   end
 
+  describe 'when deploying zip file with unzip_opts' do
+    let(:title) { 'sample.zip' }
+    let(:params) do
+      { :source => 'puppet:///modules/staging/sample.tar.gz',
+        :target => '/usr/local',
+        :unzip_opts  => '-o -f'
+      }
+    end
+    it { should contain_file('/opt/staging') }
+    it { should contain_file('/opt/staging//sample.zip') }
+    it do
+      should contain_exec('extract sample.zip').with({
+        :command => 'unzip -o -f /opt/staging//sample.zip',
+        :path    => '/usr/local/bin:/usr/bin:/bin',
+        :cwd     => '/usr/local',
+        :creates => '/usr/local/sample'
+      })
+    end
+  end
 end

--- a/spec/defines/staging_extract_spec.rb
+++ b/spec/defines/staging_extract_spec.rb
@@ -59,7 +59,24 @@ describe 'staging::extract', :type => :define do
 
     it { should contain_file('/opt/staging')
       should contain_exec('extract sample.zip').with({
-        :command => 'unzip /opt/staging//sample.zip',
+        :command => 'unzip  /opt/staging//sample.zip',
+        :path    => '/usr/local/bin:/usr/bin:/bin',
+        :cwd     => '/opt',
+        :creates => '/opt/sample'
+      })
+    }
+  end
+
+  describe 'when deploying zip with unzip_opts' do
+    let(:title) { 'sample.zip' }
+    let(:params) do
+      { :target     => '/opt',
+        :unzip_opts => '-o -f',
+      }
+    end
+    it { should contain_file('/opt/staging')
+      should contain_exec('extract sample.zip').with({
+        :command => 'unzip -o -f /opt/staging//sample.zip',
         :path    => '/usr/local/bin:/usr/bin:/bin',
         :cwd     => '/opt',
         :creates => '/opt/sample'
@@ -74,7 +91,7 @@ describe 'staging::extract', :type => :define do
 
     it { should contain_file('/opt/staging')
       should contain_exec('extract sample.zip').with({
-        :command => 'unzip /opt/staging//sample.zip',
+        :command => 'unzip  /opt/staging//sample.zip',
         :path    => '/usr/local/bin:/usr/bin:/bin',
         :cwd     => '/opt',
         :creates => '/opt/sample'
@@ -85,7 +102,6 @@ describe 'staging::extract', :type => :define do
   describe 'when deploying war' do
     let(:title) { 'sample.war' }
     let(:params) { { :target => '/opt' } }
-
     it { should contain_file('/opt/staging')
       should contain_exec('extract sample.war').with({
         :command => 'jar xf /opt/staging//sample.war',
@@ -96,11 +112,14 @@ describe 'staging::extract', :type => :define do
     }
   end
 
-  describe 'when deploying war with strip (noop)' do
+  describe 'when deploying war with strip (noop) and unzip_opts (noop)' do
     let(:title) { 'sample.war' }
-    let(:params) { { :target => '/opt',
-                     :strip  => 1, } }
-
+    let(:params) do
+      { :target     => '/opt',
+        :strip      => 1,
+        :unzip_opts => '-o -f'
+      }
+    end
     it { should contain_file('/opt/staging')
       should contain_exec('extract sample.war').with({
         :command => 'jar xf /opt/staging//sample.war',


### PR DESCRIPTION
This pull request addresses issue #81. It adds the parameter unzip_opts
for specifying additional options for the unzip command to the
staging::extract defined type and the staging::deploy defined type.

eg:
  unzip_opts => '-o -f',